### PR TITLE
feat: enhance fetch votes with nearblocks API

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,5 @@
 import { t } from './trpc';
-import { getValidatorsProcedure } from './routers';
+import { getValidators, getValidatorsProcedure } from './routers';
 import { getConfig } from './config/helper';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
 import cors from 'cors';
@@ -19,4 +19,6 @@ async function runServer() {
     middleware: cors(),
   });
   server.listen(config.port);
+
+  await getValidators();
 }

--- a/src/server/nearblocks.ts
+++ b/src/server/nearblocks.ts
@@ -8,6 +8,7 @@ async function getReceiptsPaged(
   method: string,
   cursor?: string,
   pageSize?: number, // MAX: 100
+  afterTimestampNanosec?: string,
 ): Promise<GetReceiptResponseData> {
   const config = await getConfig();
 
@@ -18,6 +19,7 @@ async function getReceiptsPaged(
         method,
         per_page: pageSize,
         cursor,
+        after_timestamp: afterTimestampNanosec,
       },
     },
   );
@@ -28,6 +30,7 @@ async function getReceiptsPaged(
 export async function getReceipts(
   accountId: string,
   method: string,
+  afterTimestampNanosec?: string,
 ): Promise<GetReceiptResponseData> {
   const txns: GetReceiptResponseData['txns'] = [];
 
@@ -39,6 +42,7 @@ export async function getReceipts(
       method,
       cursor,
       25, // Note: Each increment of 25 will count towards rate limit. For example, per page 50 will use 2 credits.
+      afterTimestampNanosec,
     );
 
     txns.push(...response.txns);

--- a/src/server/nearblocks.ts
+++ b/src/server/nearblocks.ts
@@ -19,6 +19,7 @@ async function getReceiptsPaged(
         method,
         per_page: pageSize,
         cursor,
+        order: 'desc', // by timestamp
         after_timestamp: afterTimestampNanosec,
       },
     },

--- a/src/server/routers.ts
+++ b/src/server/routers.ts
@@ -42,14 +42,14 @@ export async function getValidators(
     if (!nearBlocksFetcher) {
       const task = async () => {
         try {
-          const result = await getValidatorsFromNearBlocks(
+          const update = await getValidatorsFromNearBlocks(
             nearBlocksLastTimestampNanosec,
           );
           nearBlocksValidators = mergeValidators(
             nearBlocksValidators ?? {},
-            Object.values(result.validators),
+            Object.values(update.validators),
           );
-          nearBlocksLastTimestampNanosec = result.lastTimestampNanosec;
+          nearBlocksLastTimestampNanosec = update.lastTimestampNanosec;
         } catch (e: unknown) {
           console.error(e);
         }


### PR DESCRIPTION
1. load validator votes on server restart
2. fetch receipts from the last timestamp